### PR TITLE
Fixed Slurm control plane getting deleted by Flux

### DIFF
--- a/apps/slinky-slurm-controlplane/helmrelease.yaml
+++ b/apps/slinky-slurm-controlplane/helmrelease.yaml
@@ -13,11 +13,6 @@ spec:
       valuesKey: values.yaml
   install:
     createNamespace: true
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
   driftDetection:
     mode: disabled
   interval: 40m


### PR DESCRIPTION
Note that due to a race condition which was previously avoided by remediation, can no longer deploy slinky-slurm-controlplane and slinky-slurm-operator simultaneously via the slinky kustomize