### PR TITLE
Slinky compute nodes now preempted by Jupyter labs

### DIFF
--- a/apps/keda/helmrelease.yaml
+++ b/apps/keda/helmrelease.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: keda
+spec:
+  chart:
+    spec:
+      chart: keda
+      sourceRef:
+        kind: HelmRepository
+        name: keda
+  interval: 5m
+  install:
+    createNamespace: true

--- a/apps/keda/helmrepository.yaml
+++ b/apps/keda/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: keda
+  namespace: keda
+spec:
+  url: https://kedacore.github.io/charts
+  interval: 5m

--- a/apps/keda/kustomization.yaml
+++ b/apps/keda/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+namespace: keda
+
+resources:
+  - helmrelease.yaml
+  - helmrepository.yaml

--- a/apps/kube-prometheus-stack/defaults.yaml
+++ b/apps/kube-prometheus-stack/defaults.yaml
@@ -1,0 +1,9 @@
+prometheus:
+  prometheusSpec:
+    additionalScrapeConfigs:
+      - job_name: "slurm_exporter"
+        scrape_interval: 10s
+        scrape_timeout: 30s
+        static_configs:
+          - targets:
+            - slurm-exporter.slurm.svc.cluster.local:8080

--- a/apps/slinky-slurm-controlplane/defaults.yaml
+++ b/apps/slinky-slurm-controlplane/defaults.yaml
@@ -277,7 +277,7 @@ compute:
       # -- (integer)
       # Set the number of replicas to deploy.
       # NOTE: if empty, all nodes matching affinity will have a replica (like DaemonSet).
-      replicas: 1
+      replicas: 3 # TODO: set to max nodes in cluster
       #
       # -- (int)
       # The minimum number of seconds for which a newly created NodeSet Pod should be ready
@@ -302,7 +302,7 @@ compute:
       # -- (string)
       # Set the priority class to use.
       # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
-      priorityClassName: ""
+      priorityClassName: "slinky-low-priority"
       #
       # -- (object)
       # Set container resource requests and limits for Kubernetes Pod scheduling.
@@ -320,26 +320,20 @@ compute:
       #
       # -- (object)
       # Set affinity for Kubernetes Pod scheduling.
-      affinity: {}
-        # nodeAffinity:
-        #   requiredDuringSchedulingIgnoredDuringExecution:
-        #     nodeSelectorTerms:
-        #       - matchExpressions:
-        #           - key: "kubernetes.io/os"
-        #             operator: In
-        #             values:
-        #               - linux
-        # podAntiAffinity:
-        #   requiredDuringSchedulingIgnoredDuringExecution:
-        #     - topologyKey: "kubernetes.io/hostname"
-        #       labelSelector:
-        #         matchExpressions:
-        #           - key: "app.kubernetes.io/name"
-        #             operator: In
-        #             values:
-        #               - slurmctld
-        #               - slurmdbd
-        #               - slurmrestd
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - singleuser-server
+            topologyKey: "kubernetes.io/hostname"
+            namespaces:
+            - slurm
+            - jupyterhub
+
       #
       # -- (object)
       # Set the update strategy configuration.

--- a/apps/slinky-slurm-controlplane/kustomization.yaml
+++ b/apps/slinky-slurm-controlplane/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - namespace.yaml
   - ocirepository.yaml
   - helmrelease.yaml
+  - priorityclass.yaml

--- a/apps/slinky-slurm-controlplane/kustomization.yaml
+++ b/apps/slinky-slurm-controlplane/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - ocirepository.yaml
   - helmrelease.yaml
   - priorityclass.yaml
+  - scaledobject.yaml

--- a/apps/slinky-slurm-controlplane/priorityclass.yaml
+++ b/apps/slinky-slurm-controlplane/priorityclass.yaml
@@ -1,0 +1,6 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: slinky-low-priority
+value: -1
+globalDefault: false

--- a/apps/slinky-slurm-controlplane/scaledobject.yaml
+++ b/apps/slinky-slurm-controlplane/scaledobject.yaml
@@ -1,0 +1,20 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: dawn-radar
+spec:
+  scaleTargetRef:
+    apiVersion: slinky.slurm.net/v1alpha1
+    kind: NodeSet
+    name: slurm-compute-dawn
+  idleReplicaCount: 0
+  minReplicaCount: 1
+  maxReplicaCount: 3
+  cooldownPeriod: 600 #TODO: set to partition max job time
+  triggers:
+    - type: prometheus
+      metricType: Value
+      metadata:
+        serverAddress: http://prometheus-kube-prometheus-prometheus.prometheus:9090
+        query: slurm_partition_pending_jobs{partition="dawn"}
+        threshold: '1'


### PR DESCRIPTION
Currently assumes exclusive access to node by either a Jupyter single user server or a Slurm compute node