### PR TITLE
Added Keda autoscaling for Slinky

### DIFF
--- a/apps/keda/helmrelease.yaml
+++ b/apps/keda/helmrelease.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: keda
+spec:
+  chart:
+    spec:
+      chart: keda
+      sourceRef:
+        kind: HelmRepository
+        name: keda
+  interval: 5m
+  install:
+    createNamespace: true

--- a/apps/keda/helmrepository.yaml
+++ b/apps/keda/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: keda
+  namespace: keda
+spec:
+  url: https://kedacore.github.io/charts
+  interval: 5m

--- a/apps/keda/kustomization.yaml
+++ b/apps/keda/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+namespace: keda
+
+resources:
+  - helmrelease.yaml
+  - helmrepository.yaml

--- a/apps/kube-prometheus-stack/defaults.yaml
+++ b/apps/kube-prometheus-stack/defaults.yaml
@@ -1,0 +1,9 @@
+prometheus:
+  prometheusSpec:
+    additionalScrapeConfigs:
+      - job_name: "slurm_exporter"
+        scrape_interval: 10s
+        scrape_timeout: 30s
+        static_configs:
+          - targets:
+            - slurm-exporter.slurm.svc.cluster.local:8080

--- a/apps/slinky-slurm-controlplane/kustomization.yaml
+++ b/apps/slinky-slurm-controlplane/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - ocirepository.yaml
   - helmrelease.yaml
   - priorityclass.yaml
+  - scaledobject.yaml

--- a/apps/slinky-slurm-controlplane/scaledobject.yaml
+++ b/apps/slinky-slurm-controlplane/scaledobject.yaml
@@ -1,0 +1,20 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: dawn-radar
+spec:
+  scaleTargetRef:
+    apiVersion: slinky.slurm.net/v1alpha1
+    kind: NodeSet
+    name: slurm-compute-dawn
+  idleReplicaCount: 0
+  minReplicaCount: 1
+  maxReplicaCount: 3
+  cooldownPeriod: 600 #TODO: set to partition max job time
+  triggers:
+    - type: prometheus
+      metricType: Value
+      metadata:
+        serverAddress: http://prometheus-kube-prometheus-prometheus.prometheus:9090
+        query: slurm_partition_pending_jobs{partition="dawn"}
+        threshold: '1'


### PR DESCRIPTION
Will currently scale up when there are pending jobs in the Slurm cluster and then scale down once no jobs remain for coolDownPeriod