### PR TITLE
Fixed Slinky/Keda dependency issues

### DIFF
--- a/apps/slinky/keda-flux.yaml
+++ b/apps/slinky/keda-flux.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: keda
+  namespace: flux-system
+spec:
+  interval: 5m
+  path: "./apps/keda/"
+  sourceRef:
+    kind: GitRepository
+    name: myapps
+  prune: true

--- a/apps/slinky/kustomization.yaml
+++ b/apps/slinky/kustomization.yaml
@@ -1,5 +1,6 @@
 ---
 resources:
-  # - ../cert-manager/
-  - ../slinky-slurm-operator/
-  - ../slinky-slurm-controlplane/
+  - ./keda-flux.yaml
+  - ./slurm-flux.yaml
+  - ./namespaces.yaml
+  - ../slinky-slurm-operator

--- a/apps/slinky/namespaces.yaml
+++ b/apps/slinky/namespaces.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: slurm
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keda

--- a/apps/slinky/slurm-flux.yaml
+++ b/apps/slinky/slurm-flux.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: slinky-slurm-controlplane
+  namespace: flux-system
+spec:
+  interval: 5m
+  path: "./apps/slinky-slurm-controlplane/"
+  sourceRef:
+    kind: GitRepository
+    name: myapps
+  prune: true
+  dependsOn:
+    - name: keda


### PR DESCRIPTION
Now deploys Slinky control plane and Keda as Flux GitRepositories so can Keda can be managed as a Flux Kustomization dependency of Slinky, fixing Slinky deploy failing if Keda wasn't already deployed. Note this means that local changes won't be reflected in either of these apps if deploying through apps/slinky/kustomization