### PR TITLE
Disabled privileged Jupyter lab initContainer

### DIFF
--- a/apps/jupyterhub/configmap.yaml
+++ b/apps/jupyterhub/configmap.yaml
@@ -90,6 +90,8 @@ data:
       image:
         name: quay.io/jupyter/minimal-notebook
         tag: "2025-01-28"
+      cloudMetadata:
+        blockWithIptables: false
       profileList:
         - display_name: "Minimal environment"
           description: "To avoid too much bells and whistles: Python."


### PR DESCRIPTION
The Jupyer Helm by default spawns a privileged initContainer with NET_ADMIN capabilities to block access to the metadata server https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/main/jupyterhub/values.yaml#L373
We need to disable this through network security policy instead

NB: seems to need a teardown and redeploy to take effect